### PR TITLE
Add npm homepage metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "https://github.com/artembatura/modify-source-webpack-plugin"
   },
+  "homepage": "https://github.com/artembatura/modify-source-webpack-plugin#readme",
   "bugs": {
     "url": "https://github.com/artembatura/modify-source-webpack-plugin/issues"
   },


### PR DESCRIPTION
## Summary
- add the package homepage field pointing to the project README
- keep the existing repository and issue tracker metadata unchanged

## Validation
- node package metadata smoke
- npm pack --dry-run --ignore-scripts
- npx --yes -p @yarnpkg/cli-dist@3.2.4 yarn build
- NODE_OPTIONS=--openssl-legacy-provider npx --yes -p @yarnpkg/cli-dist@3.2.4 yarn test
- git diff --check

Note: yarn install --immutable currently reports an existing lockfile drift around @types/node. A regular Yarn 3.2.4 install completed with warnings so build and tests could run locally.